### PR TITLE
Fix segfault with newer binaries

### DIFF
--- a/src/clientmodule.cpp
+++ b/src/clientmodule.cpp
@@ -226,7 +226,7 @@ bool ClientModule::Parse()
     uint64_t address = codeSect->sh_addr;
     cs_insn* insn = cs_malloc(csHandle);
 
-    const Elf32_Shdr* gotPlt = m_image.GetSectionHeader(".got.plt");
+    const Elf32_Shdr* gotPlt = m_image.GetSectionHeader(".got");
 
     while(cs_disasm_iter(csHandle, &code, &codeSize, &address, insn))
     {
@@ -242,7 +242,7 @@ bool ClientModule::Parse()
                 //
                 // lea eax, [ebx - 0xFFFFFFFF]
                 //
-                // it's probably calculating relative offset to constant using .got.plt offset
+                // it's probably calculating relative offset to constant using .got offset
                 // previously stored in a reg as base
                 // so we'll store that offset to use later for const size hint
                 //

--- a/src/dumperbase.cpp
+++ b/src/dumperbase.cpp
@@ -3,7 +3,7 @@
 DumperBase::DumperBase(ClientModule *t_module):
     m_module(t_module)
 {
-    const Elf32_Shdr* pltGot = t_module->GetSectionHeader(".got.plt");
+    const Elf32_Shdr* pltGot = t_module->GetSectionHeader(".got");
     if(pltGot)
     {
         m_constBase = pltGot->sh_addr;

--- a/src/enumdumper.cpp
+++ b/src/enumdumper.cpp
@@ -78,13 +78,15 @@ bool EnumDumper::GetEnumOffsetsByRef(size_t t_ref, size_t* t_name, size_t* t_val
                       )
                     {
                        size_t memOffset = x86->disp + m_constBase;
-                       if(m_relData->sh_addr <= memOffset && memOffset < m_relData->sh_addr + m_relData->sh_size)
-                       {
-                           suspectEnumOffsets.insert(memOffset);
-                       }
-                       else
-                       {
-                           possibleAssertArgs.push_back(memOffset);
+                       if (m_relData) {
+                            if(m_relData->sh_addr <= memOffset && memOffset < m_relData->sh_addr + m_relData->sh_size)
+                            {
+                                suspectEnumOffsets.insert(memOffset);
+                            }
+                            else
+                            {
+                                possibleAssertArgs.push_back(memOffset);
+                            }
                        }
 
 

--- a/src/moduleimage.cpp
+++ b/src/moduleimage.cpp
@@ -235,7 +235,7 @@ bool ModuleImage::ProcessDynSymtab()
 
 void ModuleImage::UpdatePltSymbols()
 {
-    const Elf32_Shdr* gotPltSect = GetSectionHeader(".got.plt");
+    const Elf32_Shdr* gotPltSect = GetSectionHeader(".got");
     const Elf32_Shdr* pltSect = GetSectionHeader(".plt");
     const char* gotPlt = m_image + gotPltSect->sh_addr;
 


### PR DESCRIPTION
A simple fix to the segfaulting issue. 

This PR restores functionality to the interface, callbacks and EMsg dumper.
Unfortunately doesn't fix enum dumping, as I haven't found an alternative fix to the `.data.rel.ro.local` section not existing, I did basically just patch it out though with the `if (m_relData)` check.